### PR TITLE
fix www.ingonyama.com link

### DIFF
--- a/src/.hwzk.md
+++ b/src/.hwzk.md
@@ -15,7 +15,7 @@
 
 ## General HW resources and guides
 
-- [Ingonyama](www.ingonyama.com)
+- [Ingonyama](https://www.ingonyama.com/)
   - [PipeZK](https://www.microsoft.com/en-us/research/publication/pipezk-accelerating-zero-knowledge-proof-with-a-pipelined-architecture/)
   - [Papers](https://github.com/ingonyama-zk/papers)
   - [Cloud ZK](https://medium.com/@ingonyama/cloud-zk-a-toolkit-for-developing-zkp-acceleration-in-the-cloud-3d670c09c6ed)


### PR DESCRIPTION
currently will point to https://ingonyama-zk.github.io/ingopedia/www.ingonyama.com